### PR TITLE
OpenSSL put Lazarus library; Adaption for FPC

### DIFF
--- a/Lib/Protocols/OpenSSL/IdRegisterOpenSSL.pas
+++ b/Lib/Protocols/OpenSSL/IdRegisterOpenSSL.pas
@@ -1,0 +1,40 @@
+unit IdRegisterOpenSSL;
+
+interface
+
+{$i IdCompilerDefines.inc}
+
+procedure Register;
+
+implementation
+
+uses
+  IdOpenSSLOptionsClient,
+  IdOpenSSLOptions,
+  IdOpenSSLOptionsServer,
+  IdOpenSSLConsts,
+  IdOpenSSLPersistent,
+  IdOpenSSLContextClient,
+  IdOpenSSLSocketClient,
+  IdOpenSSLContext,                   
+  IdOpenSSLSocket,
+  IdOpenSSLContextServer,             
+  IdOpenSSLSocketServer,
+  IdOpenSSLExceptionResourcestrings,
+  IdOpenSSLTypes,
+  IdOpenSSLExceptions,
+  IdOpenSSLUtils,
+  IdOpenSSLIOHandlerClientBase,
+  IdOpenSSLVersion,
+  IdOpenSSLIOHandlerClient,          
+  IdOpenSSLX509,
+  IdOpenSSLIOHandlerClientServer,
+  IdOpenSSLIOHandlerServer,
+  IdOpenSSLLoader;
+
+procedure Register;
+begin
+  // TODO:
+end;
+
+end.

--- a/Lib/Protocols/OpenSSL/IntermediateCode/IdOpenSSLHeaders_conf.pas
+++ b/Lib/Protocols/OpenSSL/IntermediateCode/IdOpenSSLHeaders_conf.pas
@@ -151,7 +151,7 @@ var
   //                                        const char *section);
   function NCONF_get_string(const conf: PCONF; const group: PAnsiChar; const name: PAnsiChar): PAnsiChar;
   function NCONF_get_number_e(const conf: PCONF; const group: PAnsiChar; const name: PAnsiChar; result: PIdC_LONG): TIdC_INT;
-  function NCONF_dump_bio(const conf: PCONf; out: PBIO): TIdC_INT;
+  function NCONF_dump_bio(const conf: PCONf; out_: PBIO): TIdC_INT;
 
   //#define NCONF_get_number(c,g,n,r) NCONF_get_number_e(c,g,n,r)
 

--- a/Lib/Protocols/OpenSSL/dynamic/IdOpenSSLHeaders_conf.pas
+++ b/Lib/Protocols/OpenSSL/dynamic/IdOpenSSLHeaders_conf.pas
@@ -161,7 +161,7 @@ var
   //                                        const char *section);
   NCONF_get_string: function(const conf: PCONF; const group: PAnsiChar; const name: PAnsiChar): PAnsiChar cdecl = nil;
   NCONF_get_number_e: function(const conf: PCONF; const group: PAnsiChar; const name: PAnsiChar; result: PIdC_LONG): TIdC_INT cdecl = nil;
-  NCONF_dump_bio: function(const conf: PCONf; out: PBIO): TIdC_INT cdecl = nil;
+  NCONF_dump_bio: function(const conf: PCONf; out_: PBIO): TIdC_INT cdecl = nil;
 
   //#define NCONF_get_number(c,g,n,r) NCONF_get_number_e(c,g,n,r)
 

--- a/Lib/Protocols/OpenSSL/static/IdOpenSSLHeaders_conf.pas
+++ b/Lib/Protocols/OpenSSL/static/IdOpenSSLHeaders_conf.pas
@@ -156,7 +156,7 @@ const
   //                                        const char *section);
   function NCONF_get_string(const conf: PCONF; const group: PAnsiChar; const name: PAnsiChar): PAnsiChar cdecl; external CLibCrypto;
   function NCONF_get_number_e(const conf: PCONF; const group: PAnsiChar; const name: PAnsiChar; result: PIdC_LONG): TIdC_INT cdecl; external CLibCrypto;
-  function NCONF_dump_bio(const conf: PCONf; out: PBIO): TIdC_INT cdecl; external CLibCrypto;
+  function NCONF_dump_bio(const conf: PCONf; out_: PBIO): TIdC_INT cdecl; external CLibCrypto;
 
   //#define NCONF_get_number(c,g,n,r) NCONF_get_number_e(c,g,n,r)
 

--- a/Lib/indylaz.lpk
+++ b/Lib/indylaz.lpk
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
-  <Package Version="4">
+  <Package Version="5">
     <PathDelim Value="\"/>
     <Name Value="indylaz"/>
     <Type Value="RunAndDesignTime"/>
@@ -11,7 +11,7 @@
       <PathDelim Value="\"/>
       <SearchPaths>
         <IncludeFiles Value=".;Core;Protocols;System"/>
-        <OtherUnitFiles Value=".;Core;Protocols;System"/>
+        <OtherUnitFiles Value=".;Core;Protocols;Protocols\OpenSSL;Protocols\OpenSSL\dynamic;System"/>
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
       <Parsing>
@@ -40,7 +40,7 @@ No personal names or organizations names associated with the Indy project may be
 THIS SOFTWARE IS PROVIDED BY Chad Z. Hower (Kudzu) and the Indy Pit Crew &amp;quot;AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 "/>
     <Version Major="10" Minor="6" Release="2"/>
-    <Files Count="16">
+    <Files Count="17">
       <Item1>
         <Filename Value="Core\IdAboutVCL.pas"/>
         <UnitName Value="IdAboutVCL"/>
@@ -109,6 +109,11 @@ THIS SOFTWARE IS PROVIDED BY Chad Z. Hower (Kudzu) and the Indy Pit Crew &amp;qu
         <Filename Value="System\IdStream.pas"/>
         <UnitName Value="IdStream"/>
       </Item16>
+      <Item17>
+        <Filename Value="Protocols\OpenSSL\IdRegisterOpenSSL.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="IdRegisterOpenSSL"/>
+      </Item17>
     </Files>
     <RequiredPkgs Count="3">
       <Item1>

--- a/Lib/indylaz.pas
+++ b/Lib/indylaz.pas
@@ -8,8 +8,8 @@ interface
 
 uses
   IdAboutVCL, IdAntiFreeze, IdCoreDsnRegister, IdDsnCoreResourceStrings, IdDsnPropEdBindingVCL, 
-  IdDsnRegister, IdDsnResourceStrings, IdDsnSASLListEditorFormVCL, IdRegister, IdRegisterCore, IdStreamVCL, 
-  IdStream, LazarusPackageIntf;
+  IdDsnRegister, IdDsnResourceStrings, IdDsnSASLListEditorFormVCL, IdRegister, IdRegisterCore,
+  IdRegisterOpenSSL, IdStreamVCL, IdStream, LazarusPackageIntf;
 
 implementation
 
@@ -19,6 +19,7 @@ begin
   RegisterUnit('IdDsnRegister', @IdDsnRegister.Register);
   RegisterUnit('IdRegister', @IdRegister.Register);
   RegisterUnit('IdRegisterCore', @IdRegisterCore.Register);
+  RegisterUnit('IdRegisterOpenSSL', @IdRegisterOpenSSL.Register);
 end;
 
 initialization


### PR DESCRIPTION
Hi Fabian!

Recently I was trying to convert some of my modules that deal with RESTful requests written for Delphi 6 to Linux env. Your efforts in bringing OpenSSL >1.1.0 saved my sweat and tears, thank you!
Here are some glitches I encountered during making your code work with FPC. I also updated `indylaz.lpk` to contain your binaries, alas not till the end since `IdRegisterOpenSSL.pas` has to be extended.