### PR TITLE
Refactor IdCTypes unit for improved compatibility

### DIFF
--- a/Lib/System/IdCTypes.pas
+++ b/Lib/System/IdCTypes.pas
@@ -297,7 +297,7 @@ type
     tm_yday: TIdC_INT;        (* day in the year, range 0 to 365  *)
     tm_isdst: TIdC_INT;       (* daylight saving time             *)
     {$IFDEF LINUX}
-    // glibc struct tm extension:
+    // xjikka 20260112 glibc struct tm extension:
     // ASN1_TIME_to_tm() writes a full glibc struct tm (tm_gmtoff, tm_zone).
     // Without these fields TIdC_TM is too small, causing stack corruption
     // (e.g. invalid X509 ValidFrom/ValidTo values) on Linux targets.
@@ -313,4 +313,5 @@ type
 implementation
 
 end.
+
 

--- a/Lib/System/IdCTypes.pas
+++ b/Lib/System/IdCTypes.pas
@@ -296,6 +296,16 @@ type
     tm_wday: TIdC_INT;        (* day of the week, range 0 to 6    *)
     tm_yday: TIdC_INT;        (* day in the year, range 0 to 365  *)
     tm_isdst: TIdC_INT;       (* daylight saving time             *)
+    {$IFDEF LINUX}
+    // glibc struct tm extension:
+    // ASN1_TIME_to_tm() writes a full glibc struct tm (tm_gmtoff, tm_zone).
+    // Without these fields TIdC_TM is too small, causing stack corruption
+    // (e.g. invalid X509 ValidFrom/ValidTo values) on Linux targets.
+    // This is especially visible with FPC cross-compilation to Linux/ARM
+    // (e.g. Raspberry Pi), where X509 ValidFrom/ValidTo values become invalid.
+    tm_gmtoff: TIdC_LONG;  // seconds east of UTC
+    tm_zone: PAnsiChar;    // timezone abbreviation
+    {$ENDIF}
   end;
   PIdC_TM = ^TIdC_TM;
   PPIdC_TM = ^PIdC_TM;
@@ -303,3 +313,4 @@ type
 implementation
 
 end.
+


### PR DESCRIPTION
Fix ABI mismatch for struct tm on Linux (glibc)

On Linux/glibc (e.g. Raspberry Pi armhf), struct tm contains additional fields:

tm_gmtoff (long)
tm_zone (char*)

This makes sizeof(struct tm) 44 bytes, while current TIdC_TM is only 36 bytes (POSIX fields only).

Functions like ASN1_TIME_to_tm() write a full glibc struct tm. With the smaller Pascal record this causes stack corruption (observed as random overwrites of local variables, invalid TDateTime values such as 1899, etc.).

This PR extends TIdC_TM under {$IFDEF LINUX} to match the actual glibc layout and prevent memory corruption. No behavior change on non-Linux platforms.

Reproducible on:

Linux armhf (Raspberry Pi OS / Debian)
OpenSSL 1.1.1
Cross-compiled FPC binaries